### PR TITLE
Add Gemini model support

### DIFF
--- a/brains.py
+++ b/brains.py
@@ -34,7 +34,14 @@ class ToolFunction(TypedDict):
     parameter_descriptions: Sequence[str]
 
 
-Message = TypeVar("Message")
+class MessageDict(TypedDict, total=False):
+    """Unified message format used across brain implementations."""
+
+    role: str
+    content: str
+
+
+Message = MessageDict
 Tool = TypeVar("Tool")
 
 

--- a/gemini_brains.py
+++ b/gemini_brains.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Mapping, Sequence, Optional, Literal
+import google.generativeai as genai
+
+from brains import Brain, MessageDict
+
+Message = MessageDict
+
+@dataclass
+class GeminiBrain(Brain[Message, dict]):
+    model: str = "gemini-2.0-flash"
+    client: genai.GenerativeModel = field(init=False)
+    default_tools: Optional[list[dict]] = None
+
+    def __post_init__(self):
+        genai.configure(
+            api_key=open(
+                r"C:\Users\ew0nd\Documents\otui\secrets\gemini.txt", "r", encoding="utf-8"
+            ).read().strip()
+        )
+        self.client = genai.GenerativeModel(self.model)
+
+    def _convert_messages(self, messages: Sequence[Message]):
+        return [
+            {"role": m.get("role", "user"), "parts": [m.get("content", "")]} for m in messages
+        ]
+
+    def chat(
+        self,
+        input: str | Sequence[Message] = [],
+        model: str | None = None,
+        messages: Optional[Sequence[Message]] = None,
+        stream: bool = False,
+        format: Literal["", "json"] = "",
+        keep_alive: Optional[float | str] = None,
+        tools: Optional[list[dict]] = None,
+    ) -> Mapping[str, Any] | Iterator[Mapping[str, Any]]:
+        if isinstance(input, str):
+            input = [{"role": "user", "content": input}]
+        input = list(input)
+
+        model = model or self.model
+        messages = list(messages or []) or self.messages
+        messages = messages + input
+        gen_messages = self._convert_messages(messages)
+        gen_tools = [t.get("function", t) for t in tools] if tools else None
+
+        self.add_messages(input)
+
+        if stream:
+            resp = self.client.generate_content(
+                gen_messages, stream=True, tools=gen_tools
+            )
+            collected = ""
+            for chunk in resp:
+                text = getattr(chunk, "text", "")
+                collected += text
+                yield {"choices": [{"delta": {"content": text}}]}
+            self.messages.append({"role": "assistant", "content": collected})
+        else:
+            resp = self.client.generate_content(
+                gen_messages, stream=False, tools=gen_tools
+            )
+            text = resp.text
+            self.messages.append({"role": "assistant", "content": text})
+            return {"choices": [{"message": {"content": text}}]}
+
+    def clear_last_messages(self, n, keep=None):
+        super().clear_last_messages(n, keep)
+
+    def set_messages(self, messages: list[Message]):
+        self.messages = messages
+
+    def add_messages(self, messages: list[Message]):
+        self.messages.extend(messages)
+
+    def change_system(self, content: str):
+        if self.messages:
+            self.messages[0] = {"role": "system", "content": content}
+
+    def quick_format(self, input: str, model=None) -> dict:
+        msgs = self._convert_messages(self.messages + [{"role": "user", "content": input}])
+        resp = self.client.generate_content(msgs, stream=False)
+        import json
+        return json.loads(resp.text)

--- a/groq_brains.py
+++ b/groq_brains.py
@@ -27,10 +27,10 @@ from groq.types.chat import (
 from groq._types import NOT_GIVEN
 from groq._streaming import Stream
 from rich import print
-from brains import Brain
+from brains import Brain, MessageDict
 from vstore import VStore
 
-Message = ChatCompletionMessageParam
+Message = MessageDict
 
 
 @dataclass

--- a/roam.py
+++ b/roam.py
@@ -5,6 +5,7 @@ import random
 import re
 from typing import Callable, Generator, List, Literal, Optional, TypedDict
 from groq_brains import GroqBrain, Message
+from gemini_brains import GeminiBrain
 from eyes import Eyes
 from ui import STREAM_RESPONSE, TOOL_CALL, UI
 from rich import print
@@ -64,6 +65,7 @@ LLM_MODELS = {
     "qwen": "qwen-2.5-32b",
     "l4m": "meta-llama/llama-4-maverick-17b-128e-instruct",
     "l4s": "meta-llama/llama-4-scout-17b-16e-instruct",
+    "gflash": "gemini-2.0-flash",
 }
 
 DIFFUSION_MODLES = {
@@ -248,13 +250,21 @@ Remember to prompt each section as if it doesn't know what happened in the story
         self.resolution_preset = self.args.resolution
         self.format_tools()
 
-        self.brain = GroqBrain(
-            model=LLM_MODELS[self.args.model],
-            messages=[
-                ChatCompletionSystemMessageParam(role="system", content=self.system),
-            ],
-            default_tools=self.tools,
-        )
+        model_name = LLM_MODELS[self.args.model]
+        if model_name.startswith("gemini"):
+            self.brain = GeminiBrain(
+                model=model_name,
+                messages=[{"role": "system", "content": self.system}],
+                default_tools=self.tools,
+            )
+        else:
+            self.brain = GroqBrain(
+                model=model_name,
+                messages=[
+                    ChatCompletionSystemMessageParam(role="system", content=self.system),
+                ],
+                default_tools=self.tools,
+            )
         self.functions = {
             "generate_scene_image": {
                 "function": lambda args: ...,


### PR DESCRIPTION
## Summary
- unify brain message type via new `MessageDict`
- support Google Gemini via new `GeminiBrain`
- allow selecting `gemini-2.0-flash` in `LLM_MODELS`
- pick GeminiBrain when model name starts with `gemini`

## Testing
- `pyright` *(fails: missing dependencies)*
- `ruff check .` *(fails: unrecognized subcommand '.')*


------
https://chatgpt.com/codex/tasks/task_e_6860052a359883268d930f013516d309