### PR TITLE
Add GoogleBrain support and refactor Brain base

### DIFF
--- a/brains.py
+++ b/brains.py
@@ -14,6 +14,8 @@ from typing import (
     Callable,
 )
 from rich import print
+from vstore import VStore
+import json
 
 tool_type_mapper: Mapping[type, str] = {
     str: "string",
@@ -34,21 +36,142 @@ class ToolFunction(TypedDict):
     parameter_descriptions: Sequence[str]
 
 
-Message = TypeVar("Message")
-Tool = TypeVar("Tool")
+class BaseMessage(TypedDict, total=False):
+    """A generic chat message used across brain implementations."""
+
+    role: str
+    content: str
+
+
+class BaseToolParam(TypedDict, total=False):
+    """Generic tool parameter definition."""
+
+    type: Literal["function"]
+    function: Mapping[str, Any]
+
+
+Message = TypeVar("Message", bound=BaseMessage)
+Tool = TypeVar("Tool", bound=BaseToolParam)
 
 
 @dataclass
 class Brain(Generic[Message, Tool]):
     model: str = field(init=False)
     messages: list[Message] = field(default_factory=list)
+    default_tools: Optional[list[Tool]] = None
+    message_limit: int = 25
+    tool_message_limit: int = 1
+    query_message_limit: int = 4
+    vstore: VStore = field(init=False, default_factory=VStore)
+    latest_rag_context: Optional[list[Message]] = None
+    rag_tool_name: str = "generate_scene_image"
 
     def clear_last_messages(self, n, keep=None):
         messages = self.messages
         kept_messages = messages[-keep:] if keep is not None else []
         messages = messages[:-n] + kept_messages
 
+        self.vstore.delete_last(len(self.messages), n, keep)
         self.messages = messages
+
+    def set_messages(self, messages: list[Message]):
+        self.messages = messages
+        self.vstore.purge()
+        self.vstore.add_messages(messages)
+
+    def add_messages(self, messages: list[Message], on_index: Optional[int] = None):
+        on_index = on_index if on_index is not None else len(self.messages)
+        self.messages.extend(messages)
+        self.vstore.add_messages(messages, on_index)
+
+    def update_message_content(self, content: str, index: int):
+        message = self.messages[index]
+        if isinstance(message, Mapping) and "content" in message:
+            message["content"] = content
+            if message.get("role") != "tool":
+                self.vstore.update_content(content, index)
+
+    def change_system(self, content: str):
+        if self.messages:
+            self.messages[0] = {"role": "system", "content": content}  # type: ignore
+        else:
+            self.messages.append({"role": "system", "content": content})  # type: ignore
+        self.vstore.change_system(content)
+
+    def prepare_messages(
+        self,
+        input_messages: Sequence[Message],
+        base_messages: Optional[Sequence[Message]] = None,
+        *,
+        rag: bool = True,
+    ) -> list[Message]:
+        """Combine existing messages with the input and optionally apply RAG."""
+
+        messages = list(base_messages or self.messages)
+        messages = messages + list(input_messages)
+
+        if rag:
+            user_messages = [m for m in input_messages if m.get("role") == "user"]
+            if user_messages:
+                user_message = user_messages[-1]["content"]
+
+                filtered_messages = [(i, m) for i, m in enumerate(messages)]
+                last_tool_call_indices = [
+                    i
+                    for i, m in filtered_messages
+                    if "tool_calls" in m
+                    and m["tool_calls"][0]["function"]["name"] == self.rag_tool_name
+                ][-self.tool_message_limit :]
+                last_tool_call_indices += [i + 1 for i in last_tool_call_indices]
+
+                filtered_messages = [
+                    o
+                    for o in filtered_messages
+                    if ("content" in o[1] and o[1].get("role") != "tool")
+                    or (o[0] in last_tool_call_indices)
+                ]
+
+                filtered_count = (
+                    self.message_limit
+                    - self.tool_message_limit
+                    - self.query_message_limit
+                    - 1
+                )
+                new_filtered_messages = filtered_messages[-filtered_count:]
+                first_index = new_filtered_messages[0][0] if new_filtered_messages else 0
+                new_filtered_messages = [o[1] for o in new_filtered_messages]
+
+                if first_index > 0:
+                    query_messages = self.vstore.query(
+                        user_message,
+                        self.query_message_limit,
+                        first_index,
+                    )
+                    message = [
+                        {
+                            "role": "user",
+                            "content": "This story is loading from the middle to save memory. We already started the adventure and are in the middle of it.\nHere are some previous messages I picked for you for context:\n"
+                            + "\n".join(
+                                [f"{m['role']}: {m['content']}" for m in query_messages]
+                            )
+                            + "\nAlso, do not forget to generate an image using your tool like you were ordered! You generated one for every response but I cut it to save memory and only kept the last one."
+                            + "\nWe will now resume our story from our last point.",
+                        }
+                    ]
+                    new_filtered_messages = message + new_filtered_messages
+
+                    new_filtered_messages = [filtered_messages[0][1]] + new_filtered_messages
+
+                messages = new_filtered_messages
+                self.latest_rag_context = messages
+                with open(
+                    r"C:\Users\ew0nd\Documents\otui\chats\_context_log.json",
+                    "w",
+                    encoding="utf-8",
+                ) as f:
+                    json.dump(self.latest_rag_context, f, indent=4)
+
+        return messages
 
     @overload
     def chat(

--- a/google_brains.py
+++ b/google_brains.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+from typing import Literal, Sequence, Optional, Iterator, Mapping, Any, overload
+from google import generativeai as genai
+from brains import Brain, BaseMessage, BaseToolParam
+
+Message = BaseMessage
+Tool = BaseToolParam
+
+@dataclass
+class GoogleBrain(Brain[Message, Tool]):
+    """Brain implementation using Google's generative models."""
+
+    model: str = "gemini-pro"
+    api_key_path: str = r"C:\\Users\\ew0nd\\Documents\\otui\\secrets\\google.txt"
+    client: genai.GenerativeModel = field(init=False)
+
+    def __post_init__(self):
+        genai.configure(api_key=open(self.api_key_path, "r", encoding="utf-8").read().strip())
+        self.client = genai.GenerativeModel(self.model)
+
+    def _to_google_messages(self, messages: Sequence[Message]):
+        return [
+            {"role": "user" if m["role"] == "user" else "model", "parts": [m.get("content", "")]}
+            for m in messages
+        ]
+
+    @overload
+    def chat(
+        self,
+        input: str | Sequence[Message] = [],
+        model: str | None = None,
+        messages: Optional[Sequence[Message]] = None,
+        stream: Literal[False] = False,
+        format: Literal["", "json"] = "",
+        keep_alive: Optional[float | str] = None,
+        tools: Optional[list[Tool]] = None,
+        rag: bool = True,
+    ) -> Mapping[str, Any]: ...
+
+    @overload
+    def chat(
+        self,
+        input: str | Sequence[Message] = [],
+        model: str | None = None,
+        messages: Optional[Sequence[Message]] = None,
+        stream: Literal[True] = True,
+        format: Literal["", "json"] = "",
+        keep_alive: Optional[float | str] = None,
+        tools: Optional[list[Tool]] = None,
+        rag: bool = True,
+    ) -> Iterator[Mapping[str, Any]]: ...
+
+    def chat(
+        self,
+        input: str | Sequence[Message] = [],
+        model: str | None = None,
+        messages: Optional[Sequence[Message]] = None,
+        stream: bool = False,
+        format: Literal["", "json"] = "",
+        keep_alive: Optional[float | str] = None,
+        tools: Optional[list[Tool]] = None,
+        rag: bool = True,
+    ) -> Mapping[str, Any] | Iterator[Mapping[str, Any]]:
+        if isinstance(input, str):
+            input = [{"role": "user", "content": input}]
+        input = list(input)
+
+        model = model or self.model
+        messages = self.prepare_messages(input, messages, rag=rag)
+
+        self.add_messages(input)
+
+        google_messages = self._to_google_messages(messages)
+        return self.client.generate_content(google_messages, stream=stream, tools=tools)


### PR DESCRIPTION
## Summary
- add unified base message and tool classes in `brains`
- move vstore and tool handling logic to `Brain`
- implement `prepare_messages` helper for RAG
- update `GroqBrain` to use new base functionality
- create new `GoogleBrain` using `google.generativeai`

## Testing
- `python -m py_compile brains.py groq_brains.py google_brains.py`

------
https://chatgpt.com/codex/tasks/task_e_68600a40728c83269989cf7341bf9c36