### PR TITLE
Add image and tool toggles

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -65,7 +65,7 @@ class Prompter:
                 "hijack": "hijack",
                 "auto-hijack | ah": "toggle auto-hijack mode",
                 "show | s": "generates a picture",
-                # "auto-show | as": "toggle auto-show mode (generates a picture for every response)",
+                "auto-show | as": "toggle auto-show mode (generates a picture for every response)",
                 "messages | m": "shows the current message history",
                 "layout | ly": {
                     "meta": "change the layout of the program",


### PR DESCRIPTION
## Summary
- support automatic image generation after every response
- allow toggling of image sections, dialog and dice roll tool
- expose command line flags for new toggles
- update CLI help and auto-show command

## Testing
- `python -m py_compile roam.py ui.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ell', No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_686022d6c208832696ce50d5e89f1f58