### PR TITLE
Connect HTML UI to simple chat API

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,111 @@
+import json
+import uuid
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from groq_brains import GroqBrain, Message
+from brains import Brain
+
+CHAT_DIR = Path("chats")
+CHAT_DIR.mkdir(exist_ok=True)
+
+class Chat:
+    def __init__(self):
+        self.brain = GroqBrain()
+        if not self.brain.messages:
+            self.brain.add_messages([
+                {"role": "system", "content": "You are a helpful assistant."}
+            ])
+
+    def messages(self) -> List[Message]:
+        return self.brain.messages
+
+    def save(self, chat_id: str):
+        with open(CHAT_DIR / f"{chat_id}.json", "w") as f:
+            json.dump(self.brain.messages, f)
+
+    @staticmethod
+    def load(chat_id: str) -> "Chat":
+        chat = Chat()
+        file = CHAT_DIR / f"{chat_id}.json"
+        if file.exists():
+            chat.brain.set_messages(json.load(open(file)))
+        return chat
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+chats: Dict[str, Chat] = {}
+
+class SendRequest(BaseModel):
+    content: str
+
+class EditRequest(BaseModel):
+    index: int
+    content: str
+
+@app.post("/api/chats")
+def create_chat():
+    chat_id = str(uuid.uuid4())
+    chats[chat_id] = Chat()
+    return {"id": chat_id}
+
+@app.get("/api/chats")
+def list_chats():
+    return [{"id": cid} for cid in chats.keys()]
+
+@app.get("/api/chats/{chat_id}")
+def get_chat(chat_id: str):
+    chat = chats.get(chat_id)
+    if not chat:
+        raise HTTPException(status_code=404)
+    return {"messages": chat.messages()}
+
+@app.post("/api/chats/{chat_id}/messages")
+def send_message(chat_id: str, req: SendRequest):
+    chat = chats.get(chat_id)
+    if not chat:
+        raise HTTPException(status_code=404)
+    chat.brain.add_messages([{"role": "user", "content": req.content}])
+    answer = ""
+    for chunk in chat.brain.chat(input=req.content, stream=True):
+        delta = chunk.choices[0].delta
+        answer += delta.content or ""
+    chat.brain.add_messages([{"role": "assistant", "content": answer}])
+    chat.save(chat_id)
+    return {"content": answer}
+
+@app.post("/api/chats/{chat_id}/edit")
+def edit_message(chat_id: str, req: EditRequest):
+    chat = chats.get(chat_id)
+    if not chat:
+        raise HTTPException(status_code=404)
+    chat.brain.update_message_content(req.content, req.index)
+    chat.save(chat_id)
+    return {"status": "ok"}
+
+@app.post("/api/chats/{chat_id}/regenerate")
+def regenerate(chat_id: str):
+    chat = chats.get(chat_id)
+    if not chat:
+        raise HTTPException(status_code=404)
+    if len(chat.brain.messages) < 2:
+        raise HTTPException(status_code=400)
+    user_msg = chat.brain.messages[-2]["content"]
+    chat.brain.clear_last_messages(1)
+    answer = ""
+    for chunk in chat.brain.chat(input=user_msg, stream=True):
+        delta = chunk.choices[0].delta
+        answer += delta.content or ""
+    chat.brain.add_messages([{"role": "assistant", "content": answer}])
+    chat.save(chat_id)
+    return {"content": answer}

--- a/web/main page/app.html
+++ b/web/main page/app.html
@@ -1359,6 +1359,7 @@
         }
         const wrap = document.createElement("div");
         wrap.className = `message ${from}`;
+        wrap.dataset.index = qsa(".message", messages).length;
         wrap.style.animation = "fadeIn .2s forwards";
         wrap.dataset.rawText = text;
 
@@ -1866,13 +1867,13 @@
       }
       // --- END: MODIFICATION (FIX) ---
 
-      document.addEventListener("click", (e) => {
+      document.addEventListener("click", async (e) => {
         if (e.target.matches(".edit-btn")) {
           const btn = e.target;
           const msgEl = btn.closest(".message");
           const bubble = msgEl.querySelector(".bubble");
 
-          const finishEdit = () => {
+          const finishEdit = async () => {
             const newRawText = bubble.innerText;
             msgEl.dataset.rawText = newRawText;
 
@@ -1884,6 +1885,17 @@
             btn.textContent = "Edit";
             bubble.removeEventListener("keydown", onKeydown);
             bubble.removeEventListener("focusout", onFocusOut);
+
+            if (currentChatId) {
+              await fetch(`${API_BASE}/chats/${currentChatId}/edit`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  index: parseInt(msgEl.dataset.index, 10),
+                  content: newRawText,
+                }),
+              });
+            }
           };
 
           const onKeydown = (ev) => {
@@ -1912,8 +1924,17 @@
             finishEdit();
           }
         }
-        if (e.target.matches(".regenerate-btn"))
-          console.log("Regenerate", e.target.closest(".message"));
+        if (e.target.matches(".regenerate-btn")) {
+          const msgEl = e.target.closest(".message");
+          if (currentChatId) {
+            const res = await fetch(
+              `${API_BASE}/chats/${currentChatId}/regenerate`,
+              { method: "POST" }
+            );
+            const data = await res.json();
+            await addMessage(data.content);
+          }
+        }
       });
 
       promptForm.addEventListener("submit", async (e) => {
@@ -1948,9 +1969,18 @@
           }
         }
 
-        await new Promise((r) => setTimeout(r, 700));
-
-        await addMessage(generateRandomMultilineText());
+        if (currentChatId) {
+          const res = await fetch(
+            `${API_BASE}/chats/${currentChatId}/messages`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ content: userText }),
+            }
+          );
+          const data = await res.json();
+          await addMessage(data.content);
+        }
       });
 
       qs("#collapse-sidebar-btn").onclick = () =>
@@ -1958,16 +1988,22 @@
       qs("#toggle-sidebar-btn").onclick = () =>
         body.classList.remove("sidebar-collapsed");
 
-      qs("#new-chat-btn").onclick = qs("#new-chat-icon-btn").onclick = () => {
-        messages.innerHTML = `<div id="messages-spacer"></div>`;
-        qs("#chat-list").insertAdjacentHTML(
-          "beforeend",
-          `<li>Adventure ${qs("#chat-list").children.length + 1}</li>`
-        );
-        gallery = [];
-        assistantCount = 0;
-        closeViewer();
-      };
+      qs("#new-chat-btn").onclick =
+        qs("#new-chat-icon-btn").onclick = async () => {
+          const resp = await fetch(`${API_BASE}/chats`, { method: "POST" });
+          const data = await resp.json();
+          currentChatId = data.id;
+          messages.innerHTML = `<div id="messages-spacer"></div>`;
+          qs("#chat-list").insertAdjacentHTML(
+            "beforeend",
+            `<li data-id="${currentChatId}" class="active">Adventure ${
+              qs("#chat-list").children.length + 1
+            }</li>`
+          );
+          gallery = [];
+          assistantCount = 0;
+          closeViewer();
+        };
 
       window.addEventListener("keydown", (e) => {
         if (qs("#command-palette").classList.contains("visible")) {
@@ -2042,16 +2078,10 @@
       }
 
       async function initializeChat() {
-        qs("#chat-list").innerHTML = "<li>Initial Adventure</li>";
-
-        await addMessage(
-          `You stand at a crossroads. A weathered signpost points in three directions.
-* To the **north**, a path leads into a dark, foreboding forest.
-* To the **east**, the road winds towards a bustling port city.
-* To the **west**, a trail disappears into rolling, sun-drenched hills.
-
-What do you do? Type \`~\` to see available commands.`
-        );
+        const resp = await fetch(`${API_BASE}/chats`, { method: "POST" });
+        const data = await resp.json();
+        currentChatId = data.id;
+        qs("#chat-list").innerHTML = `<li data-id="${currentChatId}" class="active">New Adventure</li>`;
         scrollToBottom("auto");
       }
 
@@ -2188,6 +2218,8 @@ What do you do? Type \`~\` to see available commands.`
         llm: "claude-3-sonnet",
       };
 
+      const API_BASE = "/api";
+      let currentChatId = null;
       let parsedCommands = [];
 
       function executeCommand(commandKey, args = []) {


### PR DESCRIPTION
## Summary
- add a FastAPI `server.py` implementing a minimal chat backend
- update `app.html` to talk with the API for creating chats, sending messages, editing and regenerating

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68606a9a3e988326ba5c042dd77a25fa